### PR TITLE
Fix walks when the prefix doesn't match any strings

### DIFF
--- a/critbit.c
+++ b/critbit.c
@@ -302,7 +302,7 @@ int cb_tree_walk_prefixed(cb_tree_t *tree, const char *prefix,
 		}
 	}
 
-	if (memcmp(p, prefix, ulen) != 0) {
+	if (strlen((const char *)p) < ulen || memcmp(p, prefix, ulen) != 0) {
 		/* No strings match */
 		return 0;
 	}

--- a/critbit.c
+++ b/critbit.c
@@ -302,5 +302,10 @@ int cb_tree_walk_prefixed(cb_tree_t *tree, const char *prefix,
 		}
 	}
 
+	if (memcmp(p, prefix, ulen) != 0) {
+		/* No strings match */
+		return 0;
+	}
+
 	return cbt_traverse_prefixed(top, callback, baton);
 }

--- a/test.c
+++ b/test.c
@@ -192,11 +192,21 @@ static void test_prefixes(cb_tree_t *tree)
 	}
 
 	if (cb_tree_walk_prefixed(tree, "11", count_cb, &i) != 0) {
-		fprintf(stderr, "Walking with empty prefix failed\n");
+		fprintf(stderr, "Walking with prefix failed\n");
 		abort();
 	}
 	if (i != 2) {
 		fprintf(stderr, "2 items expected, but %d walked\n", i);
+		abort();
+	}
+
+	i = 0;
+	if (cb_tree_walk_prefixed(tree, "13", count_cb, &i) != 0) {
+		fprintf(stderr, "Walking with non-matching prefix failed\n");
+		abort();
+	}
+	if (i != 0) {
+		fprintf(stderr, "0 items expected, but %d walked\n", i);
 		abort();
 	}
 }

--- a/test.c
+++ b/test.c
@@ -209,6 +209,26 @@ static void test_prefixes(cb_tree_t *tree)
 		fprintf(stderr, "0 items expected, but %d walked\n", i);
 		abort();
 	}
+
+	i = 0;
+	if (cb_tree_walk_prefixed(tree, "12345678", count_cb, &i) != 0) {
+		fprintf(stderr, "Walking with long prefix failed\n");
+		abort();
+	}
+	if (i != 0) {
+		fprintf(stderr, "0 items expected, but %d walked\n", i);
+		abort();
+	}
+
+	i = 0;
+	if (cb_tree_walk_prefixed(tree, "11str", count_cb, &i) != 0) {
+		fprintf(stderr, "Walking with exactly matching prefix failed\n");
+		abort();
+	}
+	if (i != 2) {
+		fprintf(stderr, "2 items expected, but %d walked\n", i);
+		abort();
+	}
 }
 
 


### PR DESCRIPTION
Currently, the walk code doesn't check to see if any prefixes matching the
string actually exist.
